### PR TITLE
back to previous visited page from student page

### DIFF
--- a/src/js/views/students/StudentPage.jsx
+++ b/src/js/views/students/StudentPage.jsx
@@ -62,9 +62,11 @@ export default class StudentPage extends Component {
             <hr/>
             <div>
               <button className="btn btn-primary" onClick={() => {
-                this.context.router.push({
-                  pathname: `/${studentRecords[0].Faculty.toLowerCase()}`
-                });
+                if(!window.history.back()) {
+                  this.context.router.push({
+                    pathname: `/${studentRecords[0].Faculty.toLowerCase()}`
+                  });                  
+                }
               }}>Back</button>
             </div>
           </div>


### PR DESCRIPTION
For example if you want to search for http://awards.nusmods.com/?page=1&search=yangshun, then you click one of them to view the individual page. And when you click the back button, you probably want to go back to the search page to check 'the other yangshun' instead of being directed to computing page.

Of course we cannot help that much if it is just a fan of yangshun who somehow visited http://awards.nusmods.com/s/Tay_Yang_Shun directly (open in new tab have the same effect).
